### PR TITLE
Added hash comparision benchmarks.

### DIFF
--- a/tests/TrimDB.Benchmarks/Hash.cs
+++ b/tests/TrimDB.Benchmarks/Hash.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Standart.Hash.xxHash;
+using TrimDB.Core.Hashing;
+using WyHash;
+
+namespace TrimDB.Benchmarks
+{
+    public class Hash
+    {
+        public const int blockSize = 4 << 10;
+        public byte[] data = new byte[blockSize];
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var rand = new Random();
+            rand.NextBytes(data);
+        }
+
+        [Benchmark]
+        public void Murmur64()
+        {
+            var hash = new MurmurHash3();
+            hash.ComputeHash64(data);
+        }
+
+        [Benchmark]
+        public void Murmur32()
+        {
+            var hash = new MurmurHash3();
+            hash.ComputeHash32(data);
+        }
+
+        [Benchmark]
+        public void Murmur128()
+        {
+            var hash = new MurmurHash3();
+            hash.ComputeHash128(data);
+        }
+
+        [Benchmark]
+        public void Wyhash64()
+        {
+            WyHash64.ComputeHash64(data);
+        }
+
+        [Benchmark]
+        public void XXHash64()
+        {
+            xxHash64.ComputeHash(data);
+        }
+
+        [Benchmark]
+        public void XXHash32()
+        {
+            xxHash32.ComputeHash(data);
+        }
+    }
+}

--- a/tests/TrimDB.Benchmarks/Program.cs
+++ b/tests/TrimDB.Benchmarks/Program.cs
@@ -13,9 +13,7 @@ namespace TrimDB.Benchmarks
             //sl.GlobalSetup();
             //await sl.MultiThreaded();
 
-            var summary = BenchmarkRunner.Run<SkipListInsert>();
-
-
+            var summary = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/tests/TrimDB.Benchmarks/TrimDB.Benchmarks.csproj
+++ b/tests/TrimDB.Benchmarks/TrimDB.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0" />
+    <PackageReference Include="WyHash" Version="1.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/Drawaes/TrimDB/issues/4

murmur hash32 seems broken. and xxhash64 is faster.

![image](https://user-images.githubusercontent.com/2143587/80909984-720cc500-8d24-11ea-8d67-dd3f9dded497.png)
